### PR TITLE
Update to newer phpspreadsheet dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "yiisoft/yii": "~1.1",
         "php": ">=5.3",
-        "phpoffice/phpspreadsheet": "~1.8.0"
+        "phpoffice/phpspreadsheet": ">=1.8.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Currently composer.json has reference to phpspreadsheet version ~1.8.0 which means 1.8.*, which then requires php up to 7.0.
I updated it to >=1.8.0, which takes 1.22.0 and is compatible with php ^8.0.

It will be also more consistent with docs which says:
`
"require": {
    ...
    "phpoffice/phpspreadsheet": ">= 1.10.1"
    ...
  },
`

I'm not sure which version should be exactly used, but with 1.22.0 it works for me with legacy yii 1.1 code.